### PR TITLE
Add clone method

### DIFF
--- a/bls.js
+++ b/bls.js
@@ -227,6 +227,11 @@
       clear () {
         this.a_.fill(0)
       }
+      clone() {
+        const copy = new this.constructor();
+        copy.a_ = this.a_.slice(0);
+        return copy;
+      }
       // alloc new array
       _alloc () {
         return _malloc(this.a_.length * 4)


### PR DESCRIPTION
Useful addition that we are using already on a consumer library `ChainSafe/bls/`. Originally added by @mpetrunic
https://github.com/ChainSafe/bls/blob/8340a4343de095c41ac2bc3fc8bc589c01aff618/src/signature.ts#L44

```ts
public add(other: Signature): Signature {
    const agg = this.value.clone();
    agg.add(other.value);
    return new Signature(agg);
}
```