### PR TITLE
Print error stack trace on test error

### DIFF
--- a/test.js
+++ b/test.js
@@ -20,7 +20,7 @@ const curveTest = (curveType, name) => {
         console.log('all ok')
         benchAll()
       } catch (e) {
-        console.log(`TEST FAIL ${e}`)
+        console.log("TEST FAIL", e)
         assert(false)
       }
     })


### PR DESCRIPTION
```ts
console.log(`TEST FAIL ${e}`)
```
only prints the error message, omitting the stack trace.