### PR TITLE
Declare h variable

### DIFF
--- a/bls.js
+++ b/bls.js
@@ -581,7 +581,7 @@
     exports.areAllMsgDifferent = (msgs, msgSize) => {
       const n = msgs.length / msgSize
       if (msgs.length != n * msgSize) return false
-      h = {}
+      const h = {}
       for (let i = 0; i < n; i++) {
         const m = msgs.subarray(i * msgSize, (i + 1) * msgSize)
         if (m in h) return false


### PR DESCRIPTION
If the library is used on strict mode this line throws
```
ReferenceError: h is not defined
    at Object.exports.areAllMsgDifferent (/home/lion/Code/eth2.0/eth2-bls-wasm/dist/bls.js:813:9)
```