### PR TITLE
Update index-browser.js

### DIFF
--- a/browser/src/index-browser.js
+++ b/browser/src/index-browser.js
@@ -1,6 +1,6 @@
 const createModule = require('../../src/bls_c.js')
 const blsSetupFactory = require('../../src/bls.js')
-const crypto = window.crypto || window.msCrypto
+const crypto = self.crypto || self.msCrypto
 
 const getRandomValues = x => crypto.getRandomValues(x)
 const bls = blsSetupFactory(createModule, getRandomValues)


### PR DESCRIPTION
with the current implementation, there is no way to transfer the module to the web worker, I suggest replacing `window` with `self`