### PR TITLE
chore: remove node dependency

### DIFF
--- a/src/bls.js
+++ b/src/bls.js
@@ -1,11 +1,10 @@
 /**
  * @param createModule Async factory that returns an emcc initialized Module
  * In node, `const createModule = require(`./bls_c.js`)`
- * @param getRandomValues Function to get crypto quality random values
  */
 const ETH_MODE = true
 
-const _blsSetupFactory = (createModule, getRandomValues) => {
+const _blsSetupFactory = (createModule) => {
   const exports = {}
   /* eslint-disable */
   exports.BN254 = 0
@@ -809,7 +808,7 @@ const _blsSetupFactory = (createModule, getRandomValues) => {
   }
   exports.init = async (curveType = exports.ethMode ? exports.BLS12_381 : exports.BN254) => {
     exports.curveType = curveType
-    exports.getRandomValues = getRandomValues
+    exports.getRandomValues = crypto.getRandomValues.bind(crypto)
     exports.mod = await createModule({
       cryptoGetRandomValues: _cryptoGetRandomValues,
     })

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,6 @@
 const createModule = require('./bls_c.js')
 const blsSetupFactory = require('./bls')
-const crypto = require('crypto')
 
-const getRandomValues = crypto.randomFillSync
-const bls = blsSetupFactory(createModule, getRandomValues)
+const bls = blsSetupFactory(createModule)
 
 module.exports = bls


### PR DESCRIPTION
Node had support for [webcrypto](https://nodejs.org/api/webcrypto.html) for some time now.
Use it to get rid of the node dependency and allow direct usage in browser (no polyfill).